### PR TITLE
Folding support.

### DIFF
--- a/autoload/RstFold.vim
+++ b/autoload/RstFold.vim
@@ -1,0 +1,29 @@
+function s:CacheRstFold()
+python3 <<EOF
+import vim
+cb = vim.current.buffer
+cache = {}
+curlevel = maxlevel = 0
+new = False
+levels = []
+for i in range(len(cb) - 1):
+  chars = "".join(set(cb[i + 1]))
+  if len(cb[i + 1]) >= len(cb[i]) and chars in list("=-`:.'\"~^_*+#"):
+    new = True
+    if chars not in cache:
+      cache[chars] = maxlevel = maxlevel + 1
+    curlevel = cache[chars]
+  else:
+    new = False
+  levels.append("{}{}".format(">" if new else "", curlevel))
+levels.append("{}".format(curlevel))
+cb.vars["RstFoldCache"] = levels
+EOF
+endfunction
+
+function RstFold#GetRstFold()
+  if !has_key(b:, 'RstFoldCache')
+    call s:CacheRstFold()
+  endif
+  return b:RstFoldCache[v:lnum - 1]
+endfunction

--- a/ftplugin/rst.vim
+++ b/ftplugin/rst.vim
@@ -29,5 +29,12 @@ if !exists("g:rst_style") || g:rst_style != 0
     setlocal expandtab shiftwidth=3 softtabstop=3 tabstop=8
 endif
 
+set foldmethod=expr
+set foldexpr=RstFold#GetRstFold()
+
+augroup RstFold
+  autocmd TextChanged,InsertLeave <buffer> unlet! b:RstFoldCache
+augroup END
+
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
Add folding support, as proposed in #25.  This was actually surprisingly easy.
This is a Python implementation (so perhaps it should be protected by `if has('python')`, but in truth it "should be" easy to implement a vimscript version as well.  (Perhaps you can consider this a proof of concept for now.)
A cache is used and updated on-demand because vim calls `foldexpr` once per line, so it would be (quadratically) wasteful to rescan the buffer from the beginning to get the foldlevel for each line.