### PR TITLE
Folding support.

### DIFF
--- a/autoload/RstFold.vim
+++ b/autoload/RstFold.vim
@@ -1,0 +1,45 @@
+function s:CacheRstFold()
+  let b:RstFoldCache = {}
+  let header_types = {}
+  let max_level = 0
+  function! Process(match) closure
+    let curline = getcurpos()[1]
+    if has_key(b:RstFoldCache, curline - 1)
+      " For over+under-lined headers, the regex will match both at the
+      " overline and at the title itself; in that case, skip the second match.
+      return
+    endif
+    let lines = split(a:match, '\n')
+    let key = repeat(lines[-1][0], len(lines))
+    if !has_key(header_types, key)
+      let max_level += 1
+      let header_types[key] = max_level
+    endif
+    let b:RstFoldCache[curline] = header_types[key]
+  endfunction
+  let save_cursor = getcurpos()
+  silent keeppatterns %s/\v^%(%(([=`:.'"~^_*+#-])\1+\n)?.{1,2}\n([=`:.'"~^_*+#-])\2+)|%(%(([=`:.''"~^_*+#-])\3{2,}\n)?.{3,}\n([=`:.''"~^_*+#-])\4{2,})$/\=Process(submatch(0))/gn
+  call setpos('.', save_cursor)
+endfunction
+
+function RstFold#GetRstFold()
+  if !has_key(b:, 'RstFoldCache')
+    call s:CacheRstFold()
+  endif
+  if has_key(b:RstFoldCache, v:lnum)
+    return '>' . b:RstFoldCache[v:lnum]
+  else
+    return '='
+  endif
+endfunction
+
+function RstFold#GetRstFoldText()
+  if !has_key(b:, 'RstFoldCache')
+    call s:CacheRstFold()
+  endif
+  let indent = repeat('  ', b:RstFoldCache[v:foldstart] - 1)
+  let thisline = getline(v:foldstart)
+  " For over+under-lined headers, skip the overline.
+  let text = thisline =~ '^\([=`:.''"~^_*+#-]\)\1\+$' ? getline(v:foldstart + 1) : thisline
+  return indent . text
+endfunction

--- a/autoload/RstFold.vim
+++ b/autoload/RstFold.vim
@@ -1,25 +1,24 @@
 function s:CacheRstFold()
-  let b:RstFoldCache = {}
-  let header_types = {}
-  let max_level = 0
-  function! Process(match) closure
+  let closure = {'header_types': {}, 'max_level': 0, 'levels': {}}
+  function closure.Process(match) dict
     let curline = getcurpos()[1]
-    if has_key(b:RstFoldCache, curline - 1)
+    if has_key(self.levels, curline - 1)
       " For over+under-lined headers, the regex will match both at the
       " overline and at the title itself; in that case, skip the second match.
       return
     endif
     let lines = split(a:match, '\n')
     let key = repeat(lines[-1][0], len(lines))
-    if !has_key(header_types, key)
-      let max_level += 1
-      let header_types[key] = max_level
+    if !has_key(self.header_types, key)
+      let self.max_level += 1
+      let self.header_types[key] = self.max_level
     endif
-    let b:RstFoldCache[curline] = header_types[key]
+    let self.levels[curline] = self.header_types[key]
   endfunction
   let save_cursor = getcurpos()
-  silent keeppatterns %s/\v^%(%(([=`:.'"~^_*+#-])\1+\n)?.{1,2}\n([=`:.'"~^_*+#-])\2+)|%(%(([=`:.''"~^_*+#-])\3{2,}\n)?.{3,}\n([=`:.''"~^_*+#-])\4{2,})$/\=Process(submatch(0))/gn
+  silent keeppatterns %s/\v^%(%(([=`:.'"~^_*+#-])\1+\n)?.{1,2}\n([=`:.'"~^_*+#-])\2+)|%(%(([=`:.''"~^_*+#-])\3{2,}\n)?.{3,}\n([=`:.''"~^_*+#-])\4{2,})$/\=closure.Process(submatch(0))/gn
   call setpos('.', save_cursor)
+  let b:RstFoldCache = closure.levels
 endfunction
 
 function RstFold#GetRstFold()

--- a/ftplugin/rst.vim
+++ b/ftplugin/rst.vim
@@ -29,5 +29,13 @@ if !exists("g:rst_style") || g:rst_style != 0
     setlocal expandtab shiftwidth=3 softtabstop=3 tabstop=8
 endif
 
+setlocal foldmethod=expr
+setlocal foldexpr=RstFold#GetRstFold()
+setlocal foldtext=RstFold#GetRstFoldText()
+
+augroup RstFold
+  autocmd TextChanged,InsertLeave <buffer> unlet! b:RstFoldCache
+augroup END
+
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/ftplugin/rst.vim
+++ b/ftplugin/rst.vim
@@ -29,13 +29,14 @@ if !exists("g:rst_style") || g:rst_style != 0
     setlocal expandtab shiftwidth=3 softtabstop=3 tabstop=8
 endif
 
-setlocal foldmethod=expr
-setlocal foldexpr=RstFold#GetRstFold()
-setlocal foldtext=RstFold#GetRstFoldText()
-
-augroup RstFold
-  autocmd TextChanged,InsertLeave <buffer> unlet! b:RstFoldCache
-augroup END
+if has('patch-7.3.867')  " Introduced the TextChanged event.
+  setlocal foldmethod=expr
+  setlocal foldexpr=RstFold#GetRstFold()
+  setlocal foldtext=RstFold#GetRstFoldText()
+  augroup RstFold
+    autocmd TextChanged,InsertLeave <buffer> unlet! b:RstFoldCache
+  augroup END
+endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
the vimscript version!

The slightly horrible looking regex is just the alternation between the two regexes that define rstSection (with the groups renumbered as needed).

This requires vim>=7.3.627 (https://github.com/vim/vim/commit/07e31c571a13855cf67c69f3a676038510141699) so that `:s/.../\=.../gn` works; OTOH I believe this will just fail gracefully by not finding any folds for older versions.

Edit: Actually the use of function... closure means that this requires vim>=8; this could be rewritten to use function... dict (which is supported since much longer) but I can't say I really care enough about old vims :-)