### PR TITLE
Do not specify colors directly for bold/italic syntax

### DIFF
--- a/syntax/rst.vim
+++ b/syntax/rst.vim
@@ -253,8 +253,6 @@ hi def link rstHyperlinkTarget              String
 hi def link rstExDirective                  String
 hi def link rstSubstitutionDefinition       rstDirective
 hi def link rstDelimiter                    Delimiter
-hi def rstEmphasis ctermfg=13 term=italic cterm=italic gui=italic
-hi def rstStrongEmphasis ctermfg=1 term=bold cterm=bold gui=bold
 hi def link rstInterpretedTextOrHyperlinkReference  Identifier
 hi def link rstInlineLiteral                String
 hi def link rstSubstitutionReference        PreProc
@@ -264,6 +262,14 @@ hi def link rstCitationReference            Identifier
 hi def link rstHyperLinkReference           Identifier
 hi def link rstStandaloneHyperlink          Identifier
 hi def link rstCodeBlock                    String
+if exists('g:rst_use_emphasis_colors')
+    " TODO: Less arbitrary color selection
+    hi def rstEmphasis          ctermfg=13 term=italic cterm=italic gui=italic
+    hi def rstStrongEmphasis    ctermfg=1 term=bold cterm=bold gui=bold
+else
+    hi def rstEmphasis          term=italic cterm=italic gui=italic
+    hi def rstStrongEmphasis    term=bold cterm=bold gui=bold
+endif
 
 let b:current_syntax = "rst"
 


### PR DESCRIPTION
In `syntax/rst.vim`, colors for italic/bold syntax are directly specified in CUI version of Vim as high-contrast purple and red. This is not useful for low-contrast colorschemes. Here is one example I'm using:

![screenshot](https://user-images.githubusercontent.com/823277/42942562-4136f680-8b9b-11e8-8387-310b4f887c7e.png)


I removed the colors following the same manner as [syntax/html.vim](https://github.com/vim/vim/blob/f63db65b2418140d1bdbc032511f530234bd2496/runtime/syntax/html.vim#L291).
