### PR TITLE
keep [ mark unchanged after CacheRstFold operation

### DIFF
--- a/autoload/RstFold.vim
+++ b/autoload/RstFold.vim
@@ -20,8 +20,10 @@ function s:CacheRstFold()
     let self.levels[curline] = self.header_types[key]
   endfunction
   let save_cursor = getcurpos()
+  let save_mark = getpos("'[")
   silent keeppatterns %s/\v^%(%(([=`:.'"~^_*+#-])\1+\n)?.{1,2}\n([=`:.'"~^_*+#-])\2+)|%(%(([=`:.''"~^_*+#-])\3{2,}\n)?.{3,}\n([=`:.''"~^_*+#-])\4{2,})$/\=closure.Process(submatch(0))/gn
   call setpos('.', save_cursor)
+  call setpos("'[", save_mark)
   let b:RstFoldCache = closure.levels
 endfunction
 


### PR DESCRIPTION
The `%s` substitution modifies `[` mark, which is relied upon
by some plugins such as vim-unimpaired. See #32 for details.