### PR TITLE
Dont end rstComment on empty lines.

### DIFF
--- a/syntax/rst.vim
+++ b/syntax/rst.vim
@@ -59,6 +59,7 @@ syn keyword     rstTodo             contained FIXME TODO XXX NOTE
 
 execute 'syn region rstComment contained' .
       \ ' start=/.*/'
+      \ ' skip=+^$+' .
       \ ' end=/^\s\@!/ contains=rstTodo'
 
 execute 'syn region rstFootnote contained matchgroup=rstDirective' .


### PR DESCRIPTION
The following is a valid comment:
```
.. this is

   a comment
```
but the syntax file currently stops the comment at the empty line.

`skip=+^$+` is the strategy used by a bunch of other blocks; just use
the same here.