### PR TITLE
Calculate correct indentation of rST comments.

### DIFF
--- a/indent/rst.vim
+++ b/indent/rst.vim
@@ -20,13 +20,10 @@ let s:itemization_pattern = '^\s*[-*+]\s'
 let s:enumeration_pattern = '^\s*\%(\d\+\|#\)\.\s\+'
 let s:note_pattern = '^\.\. '
 
-function parastart()
-    let l:blnum = search('^\s*$', 'bcnW')
-    if l:blnum == 0
-        return 0
-    else
-        return l:blnum + 1
-    endif
+function! s:get_paragraph_start()
+    let paragraph_mark_start = getpos("'{")[1]
+    return getline(paragraph_mark_start) =~
+        \ '\S' ? paragraph_mark_start : paragraph_mark_start + 1
 endfunction
 
 function GetRSTIndent()
@@ -38,7 +35,7 @@ function GetRSTIndent()
   let ind = indent(lnum)
   let line = getline(lnum)
 
-  let psnum = parastart()
+  let psnum = s:get_paragraph_start()
   if psnum != 0
       if getline(psnum) =~ s:note_pattern
           return 3

--- a/indent/rst.vim
+++ b/indent/rst.vim
@@ -18,6 +18,16 @@ endif
 
 let s:itemization_pattern = '^\s*[-*+]\s'
 let s:enumeration_pattern = '^\s*\%(\d\+\|#\)\.\s\+'
+let s:note_pattern = '^\.\. '
+
+function parastart()
+    let l:blnum = search('^\s*$', 'bcnW')
+    if l:blnum == 0
+        return 0
+    else
+        return l:blnum + 1
+    endif
+endfunction
 
 function GetRSTIndent()
   let lnum = prevnonblank(v:lnum - 1)
@@ -27,6 +37,13 @@ function GetRSTIndent()
 
   let ind = indent(lnum)
   let line = getline(lnum)
+
+  let psnum = parastart()
+  if psnum != 0
+      if getline(psnum) =~ s:note_pattern
+          return 3
+      endif
+  endif
 
   if line =~ s:itemization_pattern
     let ind += 2


### PR DESCRIPTION
I would find that this should work, but I don’t see any change with regards to behaviour about comments in rST.

Fixes #43