### PR TITLE
Indent: Preserve indentation of directives

### DIFF
--- a/indent/rst.vim
+++ b/indent/rst.vim
@@ -40,7 +40,7 @@ function GetRSTIndent()
   let psnum = s:get_paragraph_start()
   if psnum != 0
       if getline(psnum) =~ s:note_pattern
-          let ind = 3
+          let ind = max([3, ind])
       endif
   endif
 


### PR DESCRIPTION
This patch preserves indentation in comments.  It work by removing the
explicit 3-space indentation and replaces with with an expression which
uses the current value with a minimum of three spaces.

Discussed in the mailing list:

    https://groups.google.com/g/vim_dev/c/rn8ZLDrCbYU

Thanks to Friedrich Romstedt for reporting and Christian Brabandt for
investigating the issue.