### PR TITLE
Highlight Footnote as Footnotes and not as Citations

### DIFF
--- a/syntax/rst.vim
+++ b/syntax/rst.vim
@@ -63,13 +63,17 @@ execute 'syn region rstComment contained' .
       \ ' skip=+^$+' .
       \ ' end=/^\s\@!/ contains=rstTodo'
 
-execute 'syn region rstFootnote contained matchgroup=rstDirective' .
-      \ ' start=+\[\%(\d\+\|#\%(' . s:ReferenceName . '\)\=\|\*\)\]\_s+' .
+" Note: Order matters for rstCitation and rstFootnote as the regex for
+" citations also matches numeric only patterns, e.g. [1], which are footnotes.
+" Since we define rstFootnote after rstCitation, it takes precedence, see
+" |:syn-define|.
+execute 'syn region rstCitation contained matchgroup=rstDirective' .
+      \ ' start=+\[' . s:ReferenceName . '\]\_s+' .
       \ ' skip=+^$+' .
       \ ' end=+^\s\@!+ contains=@rstCruft,@NoSpell'
 
-execute 'syn region rstCitation contained matchgroup=rstDirective' .
-      \ ' start=+\[' . s:ReferenceName . '\]\_s+' .
+execute 'syn region rstFootnote contained matchgroup=rstDirective' .
+      \ ' start=+\[\%(\d\+\|#\%(' . s:ReferenceName . '\)\=\|\*\)\]\_s+' .
       \ ' skip=+^$+' .
       \ ' end=+^\s\@!+ contains=@rstCruft,@NoSpell'
 

--- a/tests/footnotes_and_citations.txt
+++ b/tests/footnotes_and_citations.txt
@@ -1,0 +1,6 @@
+Text [1]_ with [#ref]_ footnotes [*]_ and [CIT200]_ citations.
+
+.. [1] I'm a footnote!
+.. [#ref] I'm a footnote, too.
+.. [*] I'm a footnote, too, too!
+.. [CIT200] I'm a citation.


### PR DESCRIPTION
I noticed that footnotes of the form ``[1]`` are matched as citations.
Below a bugfix which matches them correctly as footnotes.

Remark:
To literally see that they are matched wrong either
a) change the highlighting color of footnotes or citations so they are not the same
b) Use https://vim.fandom.com/wiki/Identify_the_syntax_highlighting_group_used_at_the_cursor

Implementation note:
The proposed fix uses priority ordering of syntax rules (if multiple rules match the last takes priority) as the regex for citations also matches footnotes.  More robust would be to follow the ReST spec [1] and match valid-reference names except numeric-only labels.  However, doing a "negative" string match is tricky with regexs...

You don't see it in the diff, but all this commit does is swapping the definitions of rstCitation and rstFootnote (plus adding a comment).

[1] https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#citations