### PR TITLE
Fix Doctest recognition

### DIFF
--- a/syntax/rst.vim
+++ b/syntax/rst.vim
@@ -29,8 +29,11 @@ syn region  rstQuotedLiteralBlock   matchgroup=rstDelimiter
       \ start="::\_s*\n\ze\z([!\"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]\)"
       \ end='^\z1\@!' contains=@NoSpell
 
-syn region  rstDoctestBlock         matchgroup=rstDelimiter
+syn region  rstDoctestBlock         matchgroup=rstDoctestBlockPrompt
       \ start='^>>>\s' end='^$'
+      \ contains=rstDoctestBlockPrompt
+
+syn match   rstDoctestBlockPrompt   contained '^>>>\s'
 
 syn region  rstTable                transparent start='^\n\s*+[-=+]\+' end='^$'
       \ contains=rstTableLines,@rstCruft
@@ -267,6 +270,7 @@ hi def link rstTransition                   rstSections
 hi def link rstLiteralBlock                 String
 hi def link rstQuotedLiteralBlock           String
 hi def link rstDoctestBlock                 PreProc
+hi def link rstDoctestBlockPrompt           rstDelimiter
 hi def link rstTableLines                   rstDelimiter
 hi def link rstSimpleTableLines             rstTableLines
 hi def link rstExplicitMarkup               rstDirective

--- a/syntax/rst.vim
+++ b/syntax/rst.vim
@@ -29,7 +29,7 @@ syn region  rstQuotedLiteralBlock   matchgroup=rstDelimiter
       \ start="::\_s*\n\ze\z([!\"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]\)"
       \ end='^\z1\@!' contains=@NoSpell
 
-syn region  rstDoctestBlock         oneline display matchgroup=rstDelimiter
+syn region  rstDoctestBlock         matchgroup=rstDelimiter
       \ start='^>>>\s' end='^$'
 
 syn region  rstTable                transparent start='^\n\s*+[-=+]\+' end='^$'

--- a/tests/doctest_block.txt
+++ b/tests/doctest_block.txt
@@ -1,0 +1,14 @@
+Simple doctest with multiple lines of output.
+
+>>> print('this is a Doctest block')
+this is a Doctest block
+this is a Doctest block (repeat)
+
+Subsequent prompts ``>>>`` inside a single doctest block should be highlighted.
+
+>>> print('this is a Doctest block')
+this is a Doctest block
+>>> print('this is a second Doctest block')
+this is a second Doctest block
+
+Even more text.


### PR DESCRIPTION
Doctest blocks were not correctly highlighted.
This can be checked with the test document in the first commit.

The culprit seemed to be the "oneline" argument to the docblock match, which is not applicable as docblocks span multiple lines.
I do not fully understands vim syntax but I believe "display" might also applicable.  Vim's documentation lists sufficient conditions which all do not match anymore.  You probably understand much more, so add it back if you think you can.

The last commit also highlights subsequent '>>>' contained inside the same doctest block.  This is not strictly necessary, nor a special part of ReST but in my opinion makes sense. Feel free to omit this one.