### PR TITLE
Correctly end nested comments.

### DIFF
--- a/syntax/rst.vim
+++ b/syntax/rst.vim
@@ -49,7 +49,8 @@ syn cluster rstDirectives           contains=rstFootnote,rstCitation,
       \ rstHyperlinkTarget,rstExDirective
 
 syn match   rstExplicitMarkup       '^\s*\.\.\_s'
-      \ nextgroup=@rstDirectives,rstComment,rstSubstitutionDefinition
+      \ nextgroup=@rstDirectives,rstSubstitutionDefinition
+      \ contains=rstComment
 
 " "Simple reference names are single words consisting of alphanumerics plus
 " isolated (no two adjacent) internal hyphens, underscores, periods, colons
@@ -58,10 +59,9 @@ let s:ReferenceName = '[[:alnum:]]\%([-_.:+]\?[[:alnum:]]\+\)*'
 
 syn keyword     rstTodo             contained FIXME TODO XXX NOTE
 
-execute 'syn region rstComment contained' .
-      \ ' start=/.*/'
-      \ ' skip=+^$+' .
-      \ ' end=/^\s\@!/ contains=@Spell,rstTodo'
+syn region rstComment
+      \ start='\v^\z(\s*)\.\.(\_s+[\[|_]|\_s+.*::)@!' skip=+^$+ end=/^\(\z1   \)\@!/
+      \ contains=@Spell,rstTodo
 
 " Note: Order matters for rstCitation and rstFootnote as the regex for
 " citations also matches numeric only patterns, e.g. [1], which are footnotes.

--- a/tests/comments.txt
+++ b/tests/comments.txt
@@ -1,0 +1,17 @@
+.. this is a comment
+
+.. a-directive::
+
+   plain text
+
+   .. a comment
+
+   again, not a comment
+
+.. [#] not a comment either
+
+.. a-directive-with:: args
+
+.. _not-a-comment:
+
+.. _not-a-comment-either: some://url


### PR DESCRIPTION
Previously, a comment in a directive block would incorrectly mark
all subsequent lines in the directive block as comment, because the
syn-region did not check the leading indent.  Fix that, with a test.